### PR TITLE
Rule react/no-set-state

### DIFF
--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -23,6 +23,7 @@ module.exports = {
     'react/jsx-indent': [2, 2],
     'react/jsx-indent-props': [2, 2],
     'react/jsx-no-literals': 0,
+    'react/no-set-state': 1,
 
     // overridden import rules
     'import/prefer-default-export': 2,


### PR DESCRIPTION
This change will set react/no-set-state rule to 'warn' instead 'error'.