### PR TITLE
Add esSpecCompliant option to trailing-comma rule

### DIFF
--- a/tslint-config/tslint.json
+++ b/tslint-config/tslint.json
@@ -68,6 +68,14 @@
     "promise-must-complete": true,
     "underscore-consistent-invocation": true,
     "use-named-parameter": true,
-    "typeof-compare": true
+    "typeof-compare": true,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never",
+        "esSpecCompliant": true
+      }
+    ],
   }
 }


### PR DESCRIPTION
This is preparation for babel 7 when using rest spread...
https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7#spec-compliancy

I took the same block from https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/tslint.json#L250 and add this `esSpecCompliant` prop.