### PR TITLE
no-prototype-builtins turned off

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-irregular-whitespace': 2,
     'no-negated-in-lhs': 1,
     'no-obj-calls': 2,
+    'no-prototype-builtins': 0,
     'no-regex-spaces': 2,
     'no-sparse-arrays': 2,
     'no-unexpected-multiline': 2,


### PR DESCRIPTION
ESLint doc:
https://eslint.org/docs/rules/no-prototype-builtins#disallow-use-of-objectprototypes-builtins-directly-no-prototype-builtins

Airbnb explanation:
https://github.com/airbnb/javascript#objects--prototype-builtins