### PR TITLE
Add global JSX

### DIFF
--- a/packages/eslint-config-react-js/index.js
+++ b/packages/eslint-config-react-js/index.js
@@ -25,4 +25,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
   },
+  globals: {
+    JSX: true
+  }
 };


### PR DESCRIPTION
Eslint is complaining that JSX is not defined so I needed to add something like:
```
// .eslintrc
{
  "extends": "@infinumjs/eslint-config-react-ts",
  "globals": {
	"JSX": true
  }
}
// Some comp
interface ICheckboxGroupProps {
  title: string;
  children: JSX.Element[];
} 
<CheckboxGroup ...props">
  <Checkbox ...props />
  <Checkbox ...props />
  <Checkbox ...props />
  <Checkbox ...props />
</CheckboxGroup>
```

Although this is TS, JSX is also used in React without TS.

https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors