### PR TITLE
add array-type, consistent-return, no-param-reassign

### DIFF
--- a/packages/eslint-config-core-ts/index.js
+++ b/packages/eslint-config-core-ts/index.js
@@ -32,5 +32,12 @@ module.exports = {
         },
       },
     ],
+    '@typescript-eslint/array-type': [
+      'error',
+      {
+        'default': 'generic',
+        'readonly': 'generic'
+      }
+    ],
   },
 };

--- a/packages/eslint-config-react-js/index.js
+++ b/packages/eslint-config-react-js/index.js
@@ -24,6 +24,8 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'no-param-reassign': 'warn',
+    'consistent-return': 'warn',
   },
   globals: {
     JSX: true


### PR DESCRIPTION
After going through custom rules we had defined on Messe AHEAD, I posted a question about a few of the rules and after Filip's feedback, I opened this PR to maybe add the rules he identified as good to have in the package.

One thing I'm not certain about is, if no-param-reassign and consistent-return are positioned correctly in `eslint-config-react-js`?

Link to the document with the rules: https://docs.google.com/document/d/19BSNQQMQl4QWLhd4iO2mRmBt1BJrhPoPNOvqg7yccXY/edit

**‘no-param-reassign’: ‘warn’,**
https://eslint.org/docs/rules/no-param-reassign

It’s about how we handle reassigning the parameters in a function.
```
function add (number) {
	return number++
}
```
Would return a warning.
 
```
function add (number) {
	let tempNum = number
	return tempNum++
}
```
Would be ok.


**‘consistent-return’: ‘warn’,**

https://eslint.org/docs/rules/consistent-return

Expects, that a function always returns something
```
function doSomething(condition) {
    if (condition) {
        return true;
    }
}
```
Would return a warning.
 
```
function doSomething(condition) {
    if (condition) {
        return true;
    } else {
	return false;
    }
}
```
Would be ok.


**‘@typescript-eslint/array-type’: [
      ‘error’,
      {
        ‘default’: ‘generic’,
        ‘readonly’: ‘generic’
      }
    ],**
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md

`const x: string[] = ['a', 'b'];`
Would return an error and this
 
`const y: Array<string> = ['a', 'b'];`
Would be ok.