### PR TITLE
Add the semi rule to the core js package

### DIFF
--- a/packages/eslint-config-core-js/index.js
+++ b/packages/eslint-config-core-js/index.js
@@ -13,4 +13,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
+  rules: {
+    semi: 'error',
+  },
 };


### PR DESCRIPTION
Rule: https://eslint.org/docs/rules/semi
Reasoning: Our practice is to always use semicolons in code, but `eslint:recommended` doesn't include this rule.