### PR TITLE
Add override for constructors for @typescript-eslint/explicit-member-accessibility rule

### DIFF
--- a/packages/eslint-config-core-ts/index.js
+++ b/packages/eslint-config-core-ts/index.js
@@ -32,6 +32,9 @@ module.exports = {
 			'error',
 			{
 				accessibility: 'explicit',
+				overrides: {
+					constructors: 'no-public',
+				},
 			},
 		],
 		'@typescript-eslint/naming-convention': [


### PR DESCRIPTION
As discussed here [here](https://github.com/infinum/js-linters/discussions/49).