### PR TITLE
Update eslint-plugin-react-hooks to fix the issue with meta.hasSuggestions

### DIFF
--- a/packages/eslint-config-react-js/package.json
+++ b/packages/eslint-config-react-js/package.json
@@ -26,6 +26,6 @@
 		"eslint": ">=7",
 		"eslint-plugin-jsx-a11y": ">=6",
 		"eslint-plugin-react": ">=7",
-		"eslint-plugin-react-hooks": ">=4"
+		"eslint-plugin-react-hooks": ">=4.3.0"
 	}
 }


### PR DESCRIPTION
- For some reason, >=4 is not targeting the latest version of the eslint-plugin-react-hooks package. Eslint 8 had a breaking changes, and 4.3.0 was adapting to those breaking changes, but with >=4 it targeted 4.2.0.
This had an impact in React applications that the error "Rules with suggestions must set the `meta.hasSuggestions` property to `true`" was in eslint.
Check more in: https://stackoverflow.com/questions/69578685/eslint-broken-rules-with-suggestions-must-set-the-meta-hassuggestions-propert