### PR TITLE
Add explicit function return type

### DIFF
--- a/packages/eslint-config-core-ts/index.js
+++ b/packages/eslint-config-core-ts/index.js
@@ -51,5 +51,6 @@ module.exports = {
 		'@typescript-eslint/no-inferrable-types': 'warn',
 		'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 		'@typescript-eslint/prefer-readonly': 'error',
+		'@typescript-eslint/explicit-function-return-type': ['error'],
 	},
 };


### PR DESCRIPTION
It seems like this rule used to be enabled by some recommended rulesets in eslint v4, but is no longer in v5 (or is no longer an error).

We can discuss if we might want to set some options (see [docs](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-function-return-type.md)).

Additionally, I am not sure how this would affect React apps, but for Angular I would like to enable this rule. @kristijanbambir and @isBatak do you think we should enable this for React apps as well, or should I move the rule to Angular-specific config?