### PR TITLE
Fix usage

### DIFF
--- a/packages/eslint-config-core-ts/README.md
+++ b/packages/eslint-config-core-ts/README.md
@@ -14,10 +14,11 @@ This package provides Infinum's ESLint core TypeScript [shareable config](https:
 
    ```json
    {
-   	"extends": "@infinumjs/eslint-config-core-ts",
+   	"extends": "@infinumjs/eslint-config-core-js", // optional
    	"overrides": [
    		{
    			"files": ["*.ts"],
+				"extends": "@infinumjs/eslint-config-core-ts",
    			"parserOptions": {
    				"project": ["./tsconfig.json"]
    			}

--- a/packages/eslint-config-nextjs-ts/README.md
+++ b/packages/eslint-config-nextjs-ts/README.md
@@ -14,10 +14,11 @@ This package provides Infinum's ESLint NextJS TypeScript [shareable config](http
 
    ```json
    {
-   	"extends": "@infinumjs/eslint-config-nextjs-ts",
+		"extends": "@infinumjs/eslint-config-react-js", // optional
    	"overrides": [
    		{
-   			"files": ["*.ts", "*.tsx"],
+   			"files": ["*.tsx?"],
+   			"extends": "@infinumjs/eslint-config-nextjs-ts",
    			"parserOptions": {
    				"project": ["./tsconfig.json"]
    			}

--- a/packages/eslint-config-react-ts/README.md
+++ b/packages/eslint-config-react-ts/README.md
@@ -14,10 +14,11 @@ This package provides Infinum's ESLint React TypeScript [shareable config](https
 
    ```json
    {
-   	"extends": "@infinumjs/eslint-config-react-ts",
+		"extends": "@infinumjs/eslint-config-react-js", // optional
    	"overrides": [
    		{
-   			"files": ["*.ts", "*.tsx"],
+   			"files": ["*.tsx?"],
+   			"extends": "@infinumjs/eslint-config-react-ts",
    			"parserOptions": {
    				"project": ["./tsconfig.json"]
    			}


### PR DESCRIPTION
* `ts` lint rules should apply only on `ts` files 
* `react-ts` and `next-ts` lint rules should apply only on `tsx?` files