### PR TITLE
__NEXT_DATA__ tests

### DIFF
--- a/packages/eslint-config-nextjs-ts/__tests__/no-underscore-dangle.test.ts
+++ b/packages/eslint-config-nextjs-ts/__tests__/no-underscore-dangle.test.ts
@@ -1,0 +1,38 @@
+import { suite } from 'uvu';
+import { getTester } from '@infinumjs/test-utils';
+
+import eslintConfig from '../index';
+
+const rule = 'no-underscore-dangle';
+const { validate } = getTester({
+	filePath: __filename,
+	eslintConfig: eslintConfig as any,
+	rule,
+});
+
+const test = suite(rule);
+
+test('should allow using underscores in __NEXT_DATA__', () =>
+	validate(`
+const ssrData = window.__NEXT_DATA__;
+`));
+
+test('should not allow wrong usage of __NEXT_DATA__ variations', () =>
+	validate(
+		`
+	const ssrData1 = window.__NEXT__DATA__;
+  const ssrData2 = window.___NEXT_DATA__;
+  const ssrData3 = window.__NEXT_DATA___;
+  const ssrData4 = window.__NEXT_DATA;
+  const ssrData5 = window._NEXT_DATA_;
+	`,
+		[
+			`Unexpected dangling '_' in '__NEXT__DATA__'.`,
+			`Unexpected dangling '_' in '___NEXT_DATA__'.`,
+			`Unexpected dangling '_' in '__NEXT_DATA___'.`,
+			`Unexpected dangling '_' in '__NEXT_DATA'.`,
+			`Unexpected dangling '_' in '_NEXT_DATA_'.`,
+		]
+	));
+
+test.run();

--- a/packages/eslint-config-nextjs-ts/__tests__/no-underscore-dangle.test.ts
+++ b/packages/eslint-config-nextjs-ts/__tests__/no-underscore-dangle.test.ts
@@ -15,6 +15,7 @@ const test = suite(rule);
 test('should allow using underscores in __NEXT_DATA__', () =>
 	validate(`
 const ssrData = window.__NEXT_DATA__;
+const props = this.props.__NEXT_DATA__.locale;
 `));
 
 test('should not allow wrong usage of __NEXT_DATA__ variations', () =>

--- a/packages/eslint-config-nextjs-ts/__tests__/tsconfig.json
+++ b/packages/eslint-config-nextjs-ts/__tests__/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/eslint-config-nextjs-ts/index.js
+++ b/packages/eslint-config-nextjs-ts/index.js
@@ -1,5 +1,11 @@
 module.exports = {
 	extends: ['plugin:@next/next/recommended', '@infinumjs/eslint-config-react-ts'],
+	parserOptions: {
+		tsconfigRootDir: __dirname,
+		project: ['__tests__/tsconfig.json'],
+		ecmaVersion: 2018,
+		sourceType: 'module',
+	},
 	rules: {
 		'no-underscore-dangle': ['error', { allow: ['__NEXT_DATA__'] }],
 	},

--- a/packages/eslint-config-nextjs-ts/package.json
+++ b/packages/eslint-config-nextjs-ts/package.json
@@ -12,6 +12,10 @@
 	"bugs": {
 		"url": "https://github.com/infinum/js-linters/issues"
 	},
+	"scripts": {
+		"test": "uvu -r @swc-node/register __tests__",
+		"test:watch": "watchlist src -- npm run test"
+	},
 	"homepage": "https://github.com/infinum/js-linters#readme",
 	"dependencies": {
 		"@infinumjs/eslint-config-react-ts": "^3.4.0"
@@ -21,9 +25,13 @@
 		"typescript": ">=3.3.1"
 	},
 	"devDependencies": {
+		"@infinumjs/test-utils": "^1.0.0",
+		"@swc-node/register": "^1.6.5",
 		"eslint": ">=8.14",
 		"eslint-config-next": "12.1.6",
 		"prettier": ">=2.6.2",
-		"typescript": ">=3.3.1"
+		"typescript": ">=3.3.1",
+		"uvu": "^0.5.6",
+		"watchlist": "^0.3.1"
 	}
 }


### PR DESCRIPTION
Add testing libs to @infinumjs/eslint-config-nextjs-ts package.
Add initial tests for the ```'no-underscore-dangle': ['error', { allow: ['__NEXT_DATA__'] }],``` rule.
