### PR TITLE
Fix tsconfig root dir

### DIFF
--- a/packages/eslint-config-core-ts/index.js
+++ b/packages/eslint-config-core-ts/index.js
@@ -16,7 +16,7 @@ module.exports = {
 	plugins: ['@typescript-eslint'],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
-		tsconfigRootDir: __dirname,
+		tsconfigRootDir: '.',
 		project: ['__tests__/tsconfig.json'],
 		ecmaVersion: 2018,
 		sourceType: 'module',


### PR DESCRIPTION
With the previous version, I was getting an error that tsconfig could not be found within core-ts package while using the next-ts package.