### PR TITLE
ci: change Release workflow trigger to be manual

### DIFF
--- a/.changeset/green-ducks-hammer.md
+++ b/.changeset/green-ducks-hammer.md
@@ -1,0 +1,5 @@
+---
+'@infinum/eslint-plugin': minor
+---
+
+Changed `Release` workflow trigger to be manual

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run on'
+        required: true
+        default: 'master'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v3

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,3 +1,11 @@
 # Publishing
 
 Publishing is done via GitHub Actions using [changesets](https://github.com/changesets/changesets).
+
+## How to Manually Trigger the Workflow:
+
+1. Navigate to the Actions tab in GitHub repository.
+1. Select `Release` workflow.
+1. Click on the `Run workflow` dropdown button.
+1. You'll see a field to input the branch or use the default set (master). You can simply proceed with the default or specify release branch explicitly.
+1. Click `Run workflow` to execute the workflow manually on the specified branch.


### PR DESCRIPTION
## Summary

- [X] New config
- [ ] Changes to existing config
- [ ] New custom rule
- [ ] Changes to existing custom rule
- [X] Other

### Task:

<!-- link to the task (if there is no task, create it) -->

### Documentation:

<!-- other relevant documentation that can help PR reviewer to understand the changes -->

## Description

In case of many changes merged from different PRs, we don't always want to release them separately.

## Checklist:

- [X] Code is linted and prettified
- [X] Added/updated relevant tests
- [X] Added/updated relevant docs
- [X] I have performed a self-review of my code
