### PR TITLE
feat: allow emotion css in react config

### DIFF
--- a/.changeset/spotty-snails-jam.md
+++ b/.changeset/spotty-snails-jam.md
@@ -1,0 +1,5 @@
+---
+"@infinum/eslint-plugin": minor
+---
+
+Disabled error for `emotion css prop` in React config

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -28,5 +28,6 @@ export default {
 		'react/prop-types': ['error', { skipUndeclared: true }],
 		'react/react-in-jsx-scope': 'off',
 		'react/self-closing-comp': ['warn', { component: true, html: true }],
+		'react/no-unknown-property': ['error', { ignore: ['css'] }],
 	},
 } satisfies TSESLint.Linter.Config;

--- a/tests/configs/react/react-no-unknown-property.test.ts
+++ b/tests/configs/react/react-no-unknown-property.test.ts
@@ -1,0 +1,23 @@
+import { getReactTester } from './utils';
+
+const ruleName = 'react/no-unknown-property';
+
+const { test, validate } = getReactTester(ruleName);
+
+test(`should allow "css" prop in React JSX`, () =>
+	validate(
+		`
+		const MyComponent = () =>  {
+
+      return (
+        <div css={{
+					color: 'red',
+				}}>
+          Foo
+        </div>
+      );
+    }
+		`
+	));
+
+test.run();


### PR DESCRIPTION
## Summary

- [ ] New config
- [X] Changes to existing config
- [ ] New custom rule
- [ ] Changes to existing custom rule
- [ ] Other

## Description
Fixes #119 

## Checklist:

- [x] Code is linted and prettified
- [x] Added/updated relevant tests
- [x] Added/updated relevant docs
- [x] I have performed a self-review of my code
