### PR TITLE
feat: make typealike naming-convention rule less strict

### DIFF
--- a/.changeset/popular-tips-move.md
+++ b/.changeset/popular-tips-move.md
@@ -1,0 +1,5 @@
+---
+"@infinum/eslint-plugin": patch
+---
+
+Updated `@typescript-eslint/naming-convention` format for `typeAlike` selector to `PascalCase`

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -49,7 +49,7 @@ export default {
 			},
 			{
 				selector: 'typeLike',
-				format: ['StrictPascalCase'],
+				format: ['PascalCase'],
 			},
 		],
 		'@typescript-eslint/no-inferrable-types': 'warn',

--- a/tests/configs/typescript/naming-convention.test.ts
+++ b/tests/configs/typescript/naming-convention.test.ts
@@ -96,23 +96,21 @@ test('should disallow destructed renamed boolean variable naming without is, sho
 /**
  * typeLike
  */
-test('should allow PascalCase class naming', () => validate(`class TestClass {}`));
+test('should allow PascalCase class naming', () => validate(`class TestClass {} class SSRTestClass {}`));
 
 test('should disallow non-PascalCase class naming', () =>
-	validate(`class testClass {}`, ['Class name `testClass` must match one of the following formats: StrictPascalCase']));
+	validate(`class testClass {}`, ['Class name `testClass` must match one of the following formats: PascalCase']));
 
 test('should allow PascalCase typeParameter naming', () => validate(`type TestType<T> = T;`));
 
 test('should disallow non-PascalCase typeParameter naming', () =>
-	validate(`type TestType<t> = t;`, [
-		'Type Parameter name `t` must match one of the following formats: StrictPascalCase',
-	]));
+	validate(`type TestType<t> = t;`, ['Type Parameter name `t` must match one of the following formats: PascalCase']));
 
-test('should allow PascalCase typeAlias naming', () => validate(`type TestType = string;`));
+test('should allow PascalCase typeAlias naming', () => validate(`type TestType = string; type TModel = string;`));
 
 test('should disallow non-PascalCase typeAlias naming', () =>
 	validate(`type testType = string;`, [
-		'Type Alias name `testType` must match one of the following formats: StrictPascalCase',
+		'Type Alias name `testType` must match one of the following formats: PascalCase',
 	]));
 
 test.run();


### PR DESCRIPTION
## Summary

- [ ] New config
- [x] Changes to existing config
- [ ] New custom rule
- [ ] Changes to existing custom rule
- [ ] Other

### Task:

<!-- link to the task (if there is no task, create it) -->

## Description
This PR makes `typealike` naming convention less strict as it forbid valid cases such as `TModel` etc.

## Checklist:

- [x] Code is linted and prettified
- [x] Added/updated relevant tests
- [x] Added/updated relevant docs
- [x] I have performed a self-review of my code
