### PR TITLE
feat: allow are and can prefixes for boolean variables

### DIFF
--- a/.changeset/popular-kangaroos-draw.md
+++ b/.changeset/popular-kangaroos-draw.md
@@ -1,0 +1,5 @@
+---
+"@infinum/eslint-plugin": patch
+---
+
+Updated `@typescript-eslint/naming-convention` prefixes for `boolean` variables to allow `are`

--- a/.changeset/popular-kangaroos-draw.md
+++ b/.changeset/popular-kangaroos-draw.md
@@ -2,4 +2,4 @@
 "@infinum/eslint-plugin": patch
 ---
 
-Updated `@typescript-eslint/naming-convention` prefixes for `boolean` variables to allow `are`
+Updated `@typescript-eslint/naming-convention` prefixes for `boolean` variables to allow `are` and `can`

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -39,7 +39,7 @@ export default {
 				selector: 'variable',
 				types: ['boolean'],
 				format: ['StrictPascalCase'],
-				prefix: ['is', 'should', 'has', 'are'],
+				prefix: ['is', 'should', 'has', 'are', 'can'],
 			},
 			{
 				selector: 'variable',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -39,7 +39,7 @@ export default {
 				selector: 'variable',
 				types: ['boolean'],
 				format: ['StrictPascalCase'],
-				prefix: ['is', 'should', 'has'],
+				prefix: ['is', 'should', 'has', 'are'],
 			},
 			{
 				selector: 'variable',

--- a/tests/configs/typescript/naming-convention.test.ts
+++ b/tests/configs/typescript/naming-convention.test.ts
@@ -63,6 +63,7 @@ test('should allow StrictPascalCase boolean variable naming with is, should, has
 	await validate(`const shouldTest = true;`);
 	await validate(`const hasTest = true;`);
 	await validate(`const areAllTasksCompleted = true;`);
+	await validate(`const canNavigate = true;`);
 });
 
 test('should disallow non-StrictPascalCase boolean variable naming with is, should, has prefix', async () => {
@@ -88,11 +89,12 @@ test('should allow destructed boolean variable naming without is, should, has pr
 	await validate(`const { test: shouldTest } = { test: true };`);
 	await validate(`const { test: hasTest } = { test: true };`);
 	await validate(`const { test: areAllTasksCompleted } = { test: true };`);
+	await validate(`const { test: canNavigate } = { test: true };`);
 });
 
 test('should disallow destructed renamed boolean variable naming without is, should, has prefix', () =>
 	validate(`const { test: test2 } = { test: true };`, [
-		'Variable name `test2` must have one of the following prefixes: is, should, has, are',
+		'Variable name `test2` must have one of the following prefixes: is, should, has, are, can',
 	]));
 
 /**

--- a/tests/configs/typescript/naming-convention.test.ts
+++ b/tests/configs/typescript/naming-convention.test.ts
@@ -62,6 +62,7 @@ test('should allow StrictPascalCase boolean variable naming with is, should, has
 	await validate(`const isTest = true;`);
 	await validate(`const shouldTest = true;`);
 	await validate(`const hasTest = true;`);
+	await validate(`const areAllTasksCompleted = true;`);
 });
 
 test('should disallow non-StrictPascalCase boolean variable naming with is, should, has prefix', async () => {
@@ -86,11 +87,12 @@ test('should allow destructed boolean variable naming without is, should, has pr
 	await validate(`const { test: isTest } = { test: true };`);
 	await validate(`const { test: shouldTest } = { test: true };`);
 	await validate(`const { test: hasTest } = { test: true };`);
+	await validate(`const { test: areAllTasksCompleted } = { test: true };`);
 });
 
 test('should disallow destructed renamed boolean variable naming without is, should, has prefix', () =>
 	validate(`const { test: test2 } = { test: true };`, [
-		'Variable name `test2` must have one of the following prefixes: is, should, has',
+		'Variable name `test2` must have one of the following prefixes: is, should, has, are',
 	]));
 
 /**


### PR DESCRIPTION
## Summary

- [ ] New config
- [x] Changes to existing config
- [ ] New custom rule
- [ ] Changes to existing custom rule
- [ ] Other

## Description
This PR allows `are` and `can` prefixes for boolean variable naming convention as the current config forbids valid cases such as `areAllSegmentsInCurrentLanguage`, `canNavigate` etc.

## Checklist:

- [x] Code is linted and prettified
- [x] Added/updated relevant tests
- [x] Added/updated relevant docs
- [x] I have performed a self-review of my code
